### PR TITLE
Fix budget_import_templates migration failing on Nextcloud <= 32 ("Primary index name too long")

### DIFF
--- a/budget/lib/Migration/Version001000071Date20260602.php
+++ b/budget/lib/Migration/Version001000071Date20260602.php
@@ -59,7 +59,14 @@ class Version001000071Date20260602 extends SimpleMigrationStep {
                 'notnull' => false,
             ]);
 
-            $table->setPrimaryKey(['id']);
+            // Use an explicit primary key name. Without one, Nextcloud derives a
+            // default name from the table and rejects it on installs where the
+            // table name (minus prefix) is >= 23 chars, which is the case here:
+            // "budget_import_templates" is exactly 23. The check in
+            // MigrationService::ensureOracleConstraints() then throws
+            // "Primary index name on oc_budget_import_templates is too long."
+            // This limit applies on Nextcloud <= 32 (raised to 63 only on master).
+            $table->setPrimaryKey(['id'], 'bdgt_imptpl_pk');
             $table->addIndex(['user_id'], 'bdgt_imptpl_user_idx');
             $table->addUniqueIndex(['user_id', 'name'], 'bdgt_imptpl_name_unq');
         }


### PR DESCRIPTION
## Problem

Installing/enabling the app on **Nextcloud 32 and earlier** aborts with:

> Database error when running migration `001000071Date20260602` for app budget. Primary index name on `oc_budget_import_templates` is too long.

## Cause

`Version001000071Date20260602` sets the primary key without an explicit name:

```php
$table->setPrimaryKey(['id']);
```

Nextcloud then derives a *default* primary-key name from the table name and enforces an Oracle-compatibility identifier limit in [`MigrationService::ensureOracleConstraints()`](https://github.com/nextcloud/server/blob/v32.0.9/lib/private/DB/MigrationService.php#L631):

```php
if ($isUsingDefaultName && \strlen($table->getName()) - $prefixLength >= 23) {
    throw new \InvalidArgumentException('Primary index name on "..." is too long.');
}
```

`oc_budget_import_templates` minus the `oc_` prefix is `budget_import_templates` = **exactly 23 characters**, and the rule is `>= 23`, so it throws. The check is database-agnostic, so the migration fails on any DB on affected versions. It isn't hit on Nextcloud `master`, where the limit was raised to 63 — which is likely why it slipped through.

## Fix

Give the primary key an explicit short name. This makes `isUsingDefaultName` false and bypasses the default-name length check:

```php
$table->setPrimaryKey(['id'], 'bdgt_imptpl_pk');
```

The other indexes in this migration already use short explicit names (`bdgt_imptpl_user_idx`, `bdgt_imptpl_name_unq`); the primary key was just missing one.

## Compatibility

The table is only created inside `if (!$schema->hasTable('budget_import_templates'))`, so:
- **Fresh installs** get the table with the named primary key and migrate cleanly.
- **Existing installs** (where the table already exists) are untouched — no data migration, no re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)