### PR TITLE
fix: Fixed recurring income update issue

### DIFF
--- a/budget/lib/Service/RecurringIncomeService.php
+++ b/budget/lib/Service/RecurringIncomeService.php
@@ -118,6 +118,10 @@ class RecurringIncomeService extends AbstractCrudService {
                 // Convert camelCase to snake_case for database column names
                 $columnName = strtolower(preg_replace('/([a-z])([A-Z])/', '$1_$2', $key));
                 $directDbUpdates[$columnName] = null;
+                    if (property_exists($income, $key)) {
+                        $setter = 'set' . ucfirst($key);
+                        $income->$setter(null);
+                    }
                 continue;
             }
 
@@ -130,8 +134,6 @@ class RecurringIncomeService extends AbstractCrudService {
         // Apply direct database updates for null values first
         if (!empty($directDbUpdates)) {
             $this->mapper->updateFields($id, $userId, $directDbUpdates);
-            // Reload entity to reflect the changes
-            $income = $this->find($id, $userId);
         }
 
         // Recalculate next expected date if needed

--- a/budget/tests/Unit/Service/RecurringIncomeServiceTest.php
+++ b/budget/tests/Unit/Service/RecurringIncomeServiceTest.php
@@ -336,5 +336,52 @@ class RecurringIncomeServiceTest extends TestCase {
         $this->assertCount(2, $result);
         $this->assertEquals('Salary', $result[0]->getName());
         $this->assertEquals('Freelance', $result[1]->getName());
-    }
+  }
+
+  // == updateAfterCreation ====
+  public function testUpdatePersistsNonNullChangesWhenRequestAlsoContainsNullFields(): void {
+      $income = $this->makeIncome([
+          'expectedDay' => 25,
+          'expectedMonth' => 6,
+          'nextExpectedDate' => '2026-04-25',
+      ]);
+
+      $savedIncome = null;
+
+      $this->mapper->expects($this->exactly(2))
+          ->method('find')
+          ->with(1, 'user1')
+          ->willReturnCallback(function () use ($income, &$savedIncome) {
+              return $savedIncome ?? $income;
+          });
+
+      $this->frequencyCalculator->expects($this->once())
+          ->method('calculateNextDueDate')
+          ->with('monthly', 15, null, null)
+          ->willReturn('2026-04-15');
+
+      $this->mapper->expects($this->once())
+          ->method('updateFields')
+          ->with(1, 'user1', ['expected_month' => null]);
+
+      $this->mapper->expects($this->once())
+          ->method('update')
+          ->willReturnCallback(function (RecurringIncome $i) use (&$savedIncome) {
+              $this->assertSame(15, $i->getExpectedDay());
+              $this->assertNull($i->getExpectedMonth());
+              $this->assertSame('2026-04-15', $i->getNextExpectedDate());
+
+              $savedIncome = $i;
+              return $i;
+          });
+
+      $result = $this->service->update(1, 'user1', [
+          'expectedDay' => 15,
+          'expectedMonth' => null,
+      ]);
+
+      $this->assertSame(15, $result->getExpectedDay());
+      $this->assertNull($result->getExpectedMonth());
+      $this->assertSame('2026-04-15', $result->getNextExpectedDate());
+  }
 }


### PR DESCRIPTION
This PR fixes Recurring income update issue by removing income being overriden with old data, causing the final update also remain same as original.
Also added null fields into the income object, keeping the flow same as previous but with updates
Regression test also added