### PR TITLE
feat: support concatenated CSV fields

### DIFF
--- a/budget/css/style.css
+++ b/budget/css/style.css
@@ -11407,11 +11407,11 @@ button.danger:hover {
 }
 
 /* Report account multi-select (checklist dropdown) — #299 */
-.account-multiselect {
+.custom-multiselect {
     position: relative;
 }
 
-.account-multiselect-toggle {
+.custom-multiselect-toggle {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -11428,23 +11428,22 @@ button.danger:hover {
     text-align: left;
 }
 
-.account-multiselect-toggle:hover {
+.custom-multiselect-toggle:hover {
     border-color: var(--color-primary-element);
 }
 
-.account-multiselect-toggle #report-account-summary,
-.account-multiselect-toggle > span:first-child {
+.custom-multiselect-summary {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-.account-multiselect-caret {
+.custom-multiselect-caret {
     color: var(--color-text-maxcontrast);
     flex-shrink: 0;
 }
 
-.account-multiselect-menu {
+.custom-multiselect-menu {
     position: absolute;
     z-index: 50;
     top: calc(100% + 4px);
@@ -11459,7 +11458,7 @@ button.danger:hover {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
 
-.account-multiselect-option {
+.custom-multiselect-option {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -11470,11 +11469,11 @@ button.danger:hover {
     white-space: nowrap;
 }
 
-.account-multiselect-option:hover {
+.custom-multiselect-option:hover {
     background: var(--color-background-hover);
 }
 
-.account-multiselect-all {
+.custom-multiselect-all {
     border-bottom: 1px solid var(--color-border);
     margin-bottom: 4px;
     padding-bottom: 8px;

--- a/budget/lib/Service/Import/TransactionNormalizer.php
+++ b/budget/lib/Service/Import/TransactionNormalizer.php
@@ -93,7 +93,14 @@ class TransactionNormalizer {
                 continue;
             }
 
-            if (isset($row[$column])) {
+            if (is_array($column)) {
+                if (in_array($field, ['description', 'notes', 'vendor', 'reference'], true)) {
+                    $val = $this->extractMappedTextValue($row, $column);
+                    if ($val !== null) {
+                        $transaction[$field] = $val;
+                    }
+                }
+            } elseif (isset($row[$column])) {
                 $transaction[$field] = $row[$column];
             }
         }
@@ -319,6 +326,21 @@ class TransactionNormalizer {
      */
     private function pickSource(array $txn, array $mapping, string $target, array $defaults): ?string {
         $chosen = $mapping[$target] ?? null;
+        if (is_array($chosen)) {
+            $parts = [];
+            foreach ($chosen as $key) {
+                if (is_string($key) && $key !== '' && isset($txn[$key]) && is_scalar($txn[$key])) {
+                    $val = trim((string) $txn[$key]);
+                    if ($val !== '') {
+                        $parts[] = $val;
+                    }
+                }
+            }
+            if (!empty($parts)) {
+                return implode(', ', $parts);
+            }
+        }
+
         $candidates = is_string($chosen) && $chosen !== '' ? [$chosen] : [];
         $candidates = array_merge($candidates, $defaults);
 
@@ -591,7 +613,44 @@ class TransactionNormalizer {
      */
     private function mapsColumn(array $mapping, string $field): bool {
         $column = $mapping[$field] ?? null;
-        return !is_bool($column) && $column !== null && $column !== '';
+        if (is_bool($column) || $column === null || $column === '') {
+            return false;
+        }
+        if (is_array($column)) {
+            return !empty(array_filter($column, fn($c) => !is_bool($c) && $c !== null && $c !== ''));
+        }
+        return true;
+    }
+
+    /**
+     * Extract and concatenate mapped column value(s) for text fields.
+     */
+    private function extractMappedTextValue(array $row, mixed $columnMapping): ?string {
+        if (is_array($columnMapping)) {
+            $parts = [];
+            foreach ($columnMapping as $col) {
+                if (is_string($col) && $col !== '') {
+                    $colName = (string) $col;
+                    if (isset($row[$colName]) && is_scalar($row[$colName])) {
+                        $val = trim((string) $row[$colName]);
+                        if ($val !== '') {
+                            $parts[] = $val;
+                        }
+                    }
+                }
+            }
+            return !empty($parts) ? implode(', ', $parts) : null;
+        }
+
+        if (is_string($columnMapping) && $columnMapping !== '') {
+            $colName = (string) $columnMapping;
+            if (isset($row[$colName]) && is_scalar($row[$colName])) {
+                $val = trim((string) $row[$colName]);
+                return $val !== '' ? $val : null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/budget/lib/Service/ImportTemplateService.php
+++ b/budget/lib/Service/ImportTemplateService.php
@@ -203,9 +203,26 @@ class ImportTemplateService extends AbstractCrudService {
      */
     private function sanitizeMapping(array $mapping, ?array $columnFields = null): array {
         $clean = [];
+        $allowArrayFields = ['description', 'notes', 'vendor', 'reference'];
         foreach ($columnFields ?? self::COLUMN_FIELDS as $field) {
-            if (isset($mapping[$field]) && $mapping[$field] !== '' && $mapping[$field] !== null) {
-                $clean[$field] = (string) $mapping[$field];
+            if (!isset($mapping[$field]) || $mapping[$field] === '' || $mapping[$field] === null) {
+                continue;
+            }
+
+            if (is_array($mapping[$field])) {
+                if (!in_array($field, $allowArrayFields, true)) {
+                    continue;
+                }
+                $cols = array_values(array_filter(array_map('strval', $mapping[$field]), fn($v) => trim($v) !== ''));
+                if (!empty($cols)) {
+                    $clean[$field] = $cols;
+                }
+                continue;
+            }
+
+            $val = trim((string) $mapping[$field]);
+            if ($val !== '') {
+                $clean[$field] = $val;
             }
         }
 

--- a/budget/src/modules/import/ImportModule.js
+++ b/budget/src/modules/import/ImportModule.js
@@ -5,6 +5,7 @@ import * as formatters from '../../utils/formatters.js';
 import * as dom from '../../utils/dom.js';
 import { showSuccess, showError, showWarning, showInfo } from '../../utils/notifications.js';
 import { translate as t, translatePlural as n } from '@nextcloud/l10n';
+import MultiSelect from '../../utils/multiselect.js';
 
 /**
  * Mapping targets each format can actually resolve (#338).
@@ -63,6 +64,9 @@ export default class ImportModule {
         // User-saved import template state
         this.userTemplates = [];
         this.selectedTemplate = null;
+
+        // Multiselect component instances
+        this.multiSelects = {};
     }
 
     // ============================================
@@ -304,12 +308,70 @@ export default class ImportModule {
      * @param {object} mapping Stored mapping (target -> column name)
      * @param {string[]} fields Mapping targets this call owns
      */
+    initMultiSelects() {
+        this.multiSelects = this.multiSelects || {};
+        const textFields = [
+            { key: 'description', id: 'map-description' },
+            { key: 'notes', id: 'map-notes' },
+            { key: 'vendor', id: 'map-vendor' },
+            { key: 'reference', id: 'map-reference' }
+        ];
+        textFields.forEach(({ key, id }) => {
+            const el = document.getElementById(id);
+            if (el && !this.multiSelects[key]) {
+                this.multiSelects[key] = new MultiSelect(el, {
+                    placeholder: t('budget', 'Select column(s)...'),
+                    onChange: () => this.updatePreviewMapping()
+                });
+            }
+        });
+    }
+
+    resetImportMultiSelects() {
+        Object.values(this.multiSelects || {}).forEach(multiSelect => {
+            multiSelect.setValue([]);
+        });
+    }
+
+    getSelectValue(el) {
+        if (!el) return null;
+        const key = el.id ? el.id.replace('map-', '') : null;
+        if (key && this.multiSelects && this.multiSelects[key]) {
+            const vals = this.multiSelects[key].getValue();
+            return vals.length > 0 ? vals : null;
+        }
+        if (el.multiple) {
+            const selected = Array.from(el.selectedOptions)
+                .map(opt => opt.value)
+                .filter(val => val !== '');
+            return selected.length > 0 ? selected : null;
+        }
+        return el.value || null;
+    }
+
+    setSelectValue(el, val) {
+        if (!el) return;
+        const key = el.id ? el.id.replace('map-', '') : null;
+        if (key && this.multiSelects && this.multiSelects[key]) {
+            this.multiSelects[key].setValue(val);
+            return;
+        }
+        if (el.multiple) {
+            const targetValues = Array.isArray(val) ? val : (val ? [val] : []);
+            Array.from(el.options).forEach(opt => {
+                opt.selected = targetValues.includes(opt.value);
+            });
+        } else {
+            el.value = val ?? '';
+        }
+    }
+
     applyColumnMappingToForm(mapping, fields) {
         if (!mapping || !Object.keys(mapping).length) return;
 
         fields.forEach(field => {
             const el = document.getElementById(MAPPING_SELECT_IDS[field]);
-            if (el) el.value = mapping[field] ?? '';
+            if (el) this.setSelectValue(el, mapping[field]);
         });
     }
 
@@ -617,6 +679,8 @@ export default class ImportModule {
     // ============================================
 
     setupImportEventListeners() {
+        this.initMultiSelects();
+
         // Tab navigation
         const tabButtons = document.querySelectorAll('.import-tab-btn');
         tabButtons.forEach(button => {
@@ -826,6 +890,8 @@ export default class ImportModule {
         // Kept for highlightMappedColumns, which has to turn a select's column
         // name back into its position in the preview table.
         this.previewColumns = Array.isArray(columns) ? columns.slice() : [];
+        this.initMultiSelects();
+        this.resetImportMultiSelects();
 
         const mappingSelects = {
             'map-date': document.getElementById('map-date'),
@@ -843,18 +909,23 @@ export default class ImportModule {
         };
 
         // Clear existing options and add columns
-        Object.values(mappingSelects).forEach(select => {
+        Object.entries(mappingSelects).forEach(([id, select]) => {
             if (!select) return;
-            const firstOption = select.firstElementChild;
-            select.innerHTML = '';
-            if (firstOption) select.appendChild(firstOption);
+            const key = id.replace('map-', '');
+            if (this.multiSelects && this.multiSelects[key]) {
+                this.multiSelects[key].setOptions(columns);
+            } else {
+                const firstOption = select.firstElementChild;
+                select.innerHTML = '';
+                if (firstOption) select.appendChild(firstOption);
 
-            columns.forEach((column, _index) => {
-                const option = document.createElement('option');
-                option.value = column;
-                option.textContent = column;
-                select.appendChild(option);
-            });
+                columns.forEach((column, _index) => {
+                    const option = document.createElement('option');
+                    option.value = column;
+                    option.textContent = column;
+                    select.appendChild(option);
+                });
+            }
         });
 
         // Auto-detect common column mappings
@@ -890,7 +961,7 @@ export default class ImportModule {
             );
 
             if (matchingColumn) {
-                select.value = matchingColumn;
+                this.setSelectValue(select, matchingColumn);
             }
         });
     }
@@ -916,7 +987,7 @@ export default class ImportModule {
         Object.entries(defaults).forEach(([fieldId, column]) => {
             const select = document.getElementById(fieldId);
             if (select && columns.includes(column)) {
-                select.value = column;
+                this.setSelectValue(select, column);
             }
         });
     }
@@ -946,6 +1017,9 @@ export default class ImportModule {
 
             wrapper.querySelectorAll('select').forEach(select => {
                 select.value = '';
+            });
+            wrapper.querySelectorAll('.custom-multiselect').forEach(msEl => {
+                this.setSelectValue(msEl, null);
             });
             wrapper.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
                 checkbox.checked = false;
@@ -1020,11 +1094,11 @@ export default class ImportModule {
             amount: document.getElementById('map-amount')?.value || null,
             incomeColumn: document.getElementById('map-income')?.value || null,
             expenseColumn: document.getElementById('map-expense')?.value || null,
-            description: document.getElementById('map-description')?.value || null,
-            notes: document.getElementById('map-notes')?.value || null,
+            description: this.getSelectValue(document.getElementById('map-description')),
+            notes: this.getSelectValue(document.getElementById('map-notes')),
             type: document.getElementById('map-type')?.value || null,
-            vendor: document.getElementById('map-vendor')?.value || null,
-            reference: document.getElementById('map-reference')?.value || null,
+            vendor: this.getSelectValue(document.getElementById('map-vendor')),
+            reference: this.getSelectValue(document.getElementById('map-reference')),
             category: document.getElementById('map-category')?.value || null,
             account: document.getElementById('map-account')?.value || null,
             currency: document.getElementById('map-currency')?.value || null,
@@ -1046,9 +1120,13 @@ export default class ImportModule {
         // never fired for any ordinary CSV header.
         const columns = this.previewColumns || [];
         Object.values(mapping).forEach(column => {
-            if (typeof column !== 'string' || column === '') return;
-            const header = headers[columns.indexOf(column)];
-            if (header) header.classList.add('mapped-column');
+            if (!column) return;
+            const colList = Array.isArray(column) ? column : [column];
+            colList.forEach(col => {
+                if (typeof col !== 'string' || col === '') return;
+                const header = headers[columns.indexOf(col)];
+                if (header) header.classList.add('mapped-column');
+            });
         });
     }
 
@@ -1142,9 +1220,19 @@ export default class ImportModule {
 
         const mapping = this.getCurrentMapping();
 
+        const hasNonBlankSelection = (value) => {
+            if (value === null || value === undefined || value === '') {
+                return false;
+            }
+            if (Array.isArray(value)) {
+                return value.some(v => typeof v === 'string' ? v.trim() !== '' : (v !== null && v !== undefined && v !== ''));
+            }
+            return String(value).trim() !== '';
+        };
+
         // Check required fields: date and description
         const hasDate = mapping.date !== null && mapping.date !== '';
-        const hasDescription = mapping.description !== null && mapping.description !== '';
+        const hasDescription = hasNonBlankSelection(mapping.description);
 
         // Check amount: either single amount column OR both income and expense columns
         const hasAmount = mapping.amount !== null && mapping.amount !== '';

--- a/budget/src/modules/reports/ReportsModule.js
+++ b/budget/src/modules/reports/ReportsModule.js
@@ -7,6 +7,7 @@ import Chart from 'chart.js/auto';
 import { showSuccess, showError, showWarning } from '../../utils/notifications.js';
 import { setDateValue } from '../../utils/datepicker.js';
 import { translate as t, translatePlural as n } from '@nextcloud/l10n';
+import MultiSelect from '../../utils/multiselect.js';
 
 export default class ReportsModule {
     constructor(app) {
@@ -176,6 +177,9 @@ export default class ReportsModule {
 
     /** Selected report account IDs (empty = all accounts). #299 */
     getSelectedReportAccountIds() {
+        if (this.accountMultiSelect) {
+            return this.accountMultiSelect.getValue().map(v => isNaN(v) ? v : Number(v));
+        }
         return this.selectedReportAccounts ? Array.from(this.selectedReportAccounts) : [];
     }
 
@@ -193,71 +197,27 @@ export default class ReportsModule {
 
     setupReportAccountMultiselect() {
         const wrapper = document.getElementById('report-account-multiselect');
-        const toggle = document.getElementById('report-account-toggle');
-        const menu = document.getElementById('report-account-menu');
-        if (!wrapper || !toggle || !menu) return;
-
-        toggle.addEventListener('click', (e) => {
-            e.stopPropagation();
-            const open = menu.style.display !== 'none';
-            menu.style.display = open ? 'none' : 'block';
-            toggle.setAttribute('aria-expanded', open ? 'false' : 'true');
-        });
-        document.addEventListener('click', (e) => {
-            if (!wrapper.contains(e.target)) {
-                menu.style.display = 'none';
-                toggle.setAttribute('aria-expanded', 'false');
-            }
-        });
-
-        const allCb = document.getElementById('report-account-all');
-        if (allCb) {
-            allCb.addEventListener('change', () => {
-                if (allCb.checked) {
-                    this.selectedReportAccounts.clear();
-                    document.querySelectorAll('#report-account-options input[type="checkbox"]')
-                        .forEach(cb => { cb.checked = false; });
-                    this.updateReportAccountSummary();
+        if (!wrapper) return;
+        if (!this.accountMultiSelect) {
+            this.accountMultiSelect = new MultiSelect(wrapper, {
+                placeholder: t('budget', 'All Accounts'),
+                hasAllOption: true,
+                allOptionLabel: t('budget', 'All Accounts'),
+                summaryFormatter: (count, selectedValues, optionsList) => {
+                    if (count === 0) return t('budget', 'All Accounts');
+                    if (count === 1) {
+                        const val = selectedValues[0];
+                        const opt = optionsList.find(o => String(o.value) === String(val));
+                        return opt ? opt.label : t('budget', '1 account');
+                    }
+                    return t('budget', '{count} accounts', { count });
+                },
+                onChange: (selectedValues) => {
+                    this.selectedReportAccounts = new Set(selectedValues.map(v => isNaN(v) ? v : Number(v)));
                     this.generateReport();
-                } else {
-                    // "All" can't be turned off directly — re-check it.
-                    allCb.checked = true;
                 }
             });
         }
-    }
-
-    populateReportAccountDropdown() {
-        this.selectedReportAccounts = this.selectedReportAccounts || new Set();
-        const container = document.getElementById('report-account-options');
-        if (!container) return;
-
-        // Drop selected ids that no longer exist
-        this.selectedReportAccounts.forEach(id => {
-            if (!this.accounts?.some(a => a.id === id)) this.selectedReportAccounts.delete(id);
-        });
-
-        container.innerHTML = '';
-        if (Array.isArray(this.accounts)) {
-            this.accounts.forEach(account => {
-                const label = document.createElement('label');
-                label.className = 'account-multiselect-option';
-                const cb = document.createElement('input');
-                cb.type = 'checkbox';
-                cb.value = account.id;
-                cb.checked = this.selectedReportAccounts.has(account.id);
-                cb.addEventListener('change', () => this.onReportAccountToggle(cb, account.id));
-                const span = document.createElement('span');
-                span.textContent = account.name;
-                label.appendChild(cb);
-                label.appendChild(span);
-                container.appendChild(label);
-            });
-        }
-        const allCb = document.getElementById('report-account-all');
-        if (allCb) allCb.checked = this.selectedReportAccounts.size === 0;
-        this.updateReportAccountSummary();
-        this.syncExcludeSharedToggle();
     }
 
     /**
@@ -273,30 +233,22 @@ export default class ReportsModule {
         if (cb) cb.checked = this.excludeShared;
     }
 
-    onReportAccountToggle(cb, accountId) {
-        if (cb.checked) {
-            this.selectedReportAccounts.add(accountId);
-        } else {
-            this.selectedReportAccounts.delete(accountId);
-        }
-        const allCb = document.getElementById('report-account-all');
-        if (allCb) allCb.checked = this.selectedReportAccounts.size === 0;
-        this.updateReportAccountSummary();
-        this.generateReport();
-    }
+    populateReportAccountDropdown() {
+        this.setupReportAccountMultiselect();
+        this.selectedReportAccounts = this.selectedReportAccounts || new Set();
 
-    updateReportAccountSummary() {
-        const summary = document.getElementById('report-account-summary');
-        if (!summary) return;
-        const ids = this.getSelectedReportAccountIds();
-        if (ids.length === 0) {
-            summary.textContent = t('budget', 'All Accounts');
-        } else if (ids.length === 1) {
-            const acc = this.accounts?.find(a => a.id === ids[0]);
-            summary.textContent = acc ? acc.name : t('budget', '1 account');
-        } else {
-            summary.textContent = t('budget', '{count} accounts', { count: ids.length });
+        // Drop selected ids that no longer exist
+        this.selectedReportAccounts.forEach(id => {
+            if (!this.accounts?.some(a => a.id === id)) this.selectedReportAccounts.delete(id);
+        });
+
+        if (this.accountMultiSelect) {
+            const options = (this.accounts || []).map(a => ({ value: a.id, label: a.name }));
+            this.accountMultiSelect.setOptions(options);
+            this.accountMultiSelect.setValue(Array.from(this.selectedReportAccounts));
         }
+
+        this.syncExcludeSharedToggle();
     }
 
     // ===== Saved reports (#299) =====

--- a/budget/src/utils/multiselect.js
+++ b/budget/src/utils/multiselect.js
@@ -1,0 +1,274 @@
+/**
+ * MultiSelect - Reusable checklist dropdown component
+ */
+import { translate as t } from '@nextcloud/l10n';
+
+export class MultiSelect {
+    /**
+     * @param {HTMLElement|string} container - Container element or selector
+     * @param {Object} [options] - Configuration options
+     * @param {string} [options.placeholder] - Text when no item is selected
+     * @param {Function} [options.onChange] - Selection change callback
+     */
+    constructor(container, options = {}) {
+        this.container = typeof container === 'string' ? document.querySelector(container) : container;
+        if (!this.container) {
+            throw new Error('MultiSelect container element not found');
+        }
+
+        this.placeholder = options.placeholder || t('budget', 'Select column(s)...');
+        this.onChange = options.onChange || null;
+        this.hasAllOption = options.hasAllOption || false;
+        this.allOptionLabel = options.allOptionLabel || t('budget', 'All');
+        this.summaryFormatter = options.summaryFormatter || null;
+
+        this.optionsList = [];
+        this.selectedValues = new Set();
+        this._documentClickHandler = null;
+
+        this.init();
+    }
+
+    init() {
+        this.container.innerHTML = '';
+        this.container.classList.add('custom-multiselect');
+
+        // Toggle button
+        this.toggleBtn = document.createElement('button');
+        this.toggleBtn.type = 'button';
+        this.toggleBtn.className = 'custom-multiselect-toggle';
+        this.toggleBtn.setAttribute('aria-haspopup', 'true');
+        this.toggleBtn.setAttribute('aria-expanded', 'false');
+
+        this.summarySpan = document.createElement('span');
+        this.summarySpan.className = 'custom-multiselect-summary';
+        this.summarySpan.textContent = this.placeholder;
+
+        this.caretSpan = document.createElement('span');
+        this.caretSpan.className = 'custom-multiselect-caret';
+        this.caretSpan.setAttribute('aria-hidden', 'true');
+        this.caretSpan.textContent = '▾';
+
+        this.toggleBtn.appendChild(this.summarySpan);
+        this.toggleBtn.appendChild(this.caretSpan);
+
+        // Menu container
+        this.menu = document.createElement('div');
+        this.menu.className = 'custom-multiselect-menu';
+        this.menu.setAttribute('role', 'group');
+        this.menu.style.display = 'none';
+
+        // Options wrapper
+        this.optionsContainer = document.createElement('div');
+        this.optionsContainer.className = 'custom-multiselect-options';
+        this.menu.appendChild(this.optionsContainer);
+
+        this.container.appendChild(this.toggleBtn);
+        this.container.appendChild(this.menu);
+
+        this.bindEvents();
+    }
+
+    bindEvents() {
+        this.toggleBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const isOpen = this.menu.style.display !== 'none';
+            if (isOpen) {
+                this.close();
+            } else {
+                this.open();
+            }
+        });
+
+        this._documentClickHandler = (e) => {
+            if (!this.container.contains(e.target)) {
+                this.close();
+            }
+        };
+        document.addEventListener('click', this._documentClickHandler);
+    }
+
+    open() {
+        this.menu.style.display = 'block';
+        this.toggleBtn.setAttribute('aria-expanded', 'true');
+    }
+
+    close() {
+        this.menu.style.display = 'none';
+        this.toggleBtn.setAttribute('aria-expanded', 'false');
+    }
+
+    /**
+     * Set available dropdown options
+     * @param {Array<string|number|{value: string|number, label: string}>} items
+     */
+    setOptions(items = []) {
+        this.optionsList = items.map(item => {
+            if (item !== null && typeof item === 'object' && 'value' in item) {
+                return { value: String(item.value), label: String(item.label) };
+            }
+            return { value: String(item), label: String(item) };
+        });
+
+        // Retain only selected values that still exist in options
+        const currentVals = new Set(this.selectedValues);
+        this.selectedValues.clear();
+        currentVals.forEach(val => {
+            if (this.optionsList.some(opt => opt.value === val)) {
+                this.selectedValues.add(val);
+            }
+        });
+
+        this.renderOptions();
+        this.updateSummary();
+    }
+
+    renderOptions() {
+        this.optionsContainer.innerHTML = '';
+
+        if (this.hasAllOption) {
+            const allLabel = document.createElement('label');
+            allLabel.className = 'custom-multiselect-option custom-multiselect-all';
+
+            const allCb = document.createElement('input');
+            allCb.type = 'checkbox';
+            allCb.checked = this.selectedValues.size === 0;
+
+            allCb.addEventListener('change', () => {
+                if (allCb.checked) {
+                    this.selectedValues.clear();
+                    const checkboxes = this.optionsContainer.querySelectorAll('.custom-multiselect-option:not(.custom-multiselect-all) input[type="checkbox"]');
+                    checkboxes.forEach(cb => { cb.checked = false; });
+                    this.updateSummary();
+                    if (typeof this.onChange === 'function') {
+                        this.onChange(this.getValue());
+                    }
+                } else {
+                    allCb.checked = true;
+                }
+            });
+
+            const allSpan = document.createElement('span');
+            allSpan.textContent = this.allOptionLabel;
+
+            allLabel.appendChild(allCb);
+            allLabel.appendChild(allSpan);
+            this.optionsContainer.appendChild(allLabel);
+        }
+
+        if (this.optionsList.length === 0) {
+            const emptyLabel = document.createElement('div');
+            emptyLabel.style.padding = '6px 8px';
+            emptyLabel.style.color = 'var(--color-text-maxcontrast)';
+            emptyLabel.style.fontStyle = 'italic';
+            emptyLabel.textContent = t('budget', 'No options available');
+            this.optionsContainer.appendChild(emptyLabel);
+            return;
+        }
+
+        this.optionsList.forEach(opt => {
+            const label = document.createElement('label');
+            label.className = 'custom-multiselect-option';
+
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.value = opt.value;
+            cb.checked = this.selectedValues.has(opt.value);
+
+            cb.addEventListener('change', () => {
+                if (cb.checked) {
+                    this.selectedValues.add(opt.value);
+                } else {
+                    this.selectedValues.delete(opt.value);
+                }
+                const allCb = this.optionsContainer.querySelector('.custom-multiselect-all input[type="checkbox"]');
+                if (allCb) {
+                    allCb.checked = this.selectedValues.size === 0;
+                }
+                this.updateSummary();
+                if (typeof this.onChange === 'function') {
+                    this.onChange(this.getValue());
+                }
+            });
+
+            const span = document.createElement('span');
+            span.textContent = opt.label;
+
+            label.appendChild(cb);
+            label.appendChild(span);
+            this.optionsContainer.appendChild(label);
+        });
+    }
+
+    /**
+     * Get array of selected option values
+     * @returns {Array<string>}
+     */
+    getValue() {
+        return Array.from(this.selectedValues);
+    }
+
+    /**
+     * Set selected values
+     * @param {string|Array<string>} values
+     * @param {boolean} [triggerChange=false]
+     */
+    setValue(values, triggerChange = false) {
+        this.selectedValues.clear();
+
+        if (values !== null && values !== undefined) {
+            const valArray = Array.isArray(values) ? values : [values];
+            valArray.forEach(val => {
+                const strVal = String(val);
+                if (this.optionsList.length === 0 || this.optionsList.some(opt => opt.value === strVal)) {
+                    this.selectedValues.add(strVal);
+                }
+            });
+        }
+
+        // Sync checkboxes in DOM
+        const checkboxes = this.optionsContainer.querySelectorAll('.custom-multiselect-option:not(.custom-multiselect-all) input[type="checkbox"]');
+        checkboxes.forEach(cb => {
+            cb.checked = this.selectedValues.has(cb.value);
+        });
+        const allCb = this.optionsContainer.querySelector('.custom-multiselect-all input[type="checkbox"]');
+        if (allCb) {
+            allCb.checked = this.selectedValues.size === 0;
+        }
+
+        this.updateSummary();
+
+        if (triggerChange && typeof this.onChange === 'function') {
+            this.onChange(this.getValue());
+        }
+    }
+
+    updateSummary() {
+        const count = this.selectedValues.size;
+        if (typeof this.summaryFormatter === 'function') {
+            this.summarySpan.textContent = this.summaryFormatter(count, Array.from(this.selectedValues), this.optionsList);
+            return;
+        }
+
+        if (count === 0) {
+            this.summarySpan.textContent = this.placeholder;
+        } else if (count === 1) {
+            const val = Array.from(this.selectedValues)[0];
+            const opt = this.optionsList.find(o => o.value === val);
+            this.summarySpan.textContent = opt ? opt.label : val;
+        } else {
+            this.summarySpan.textContent = t('budget', '{count} columns selected', { count });
+        }
+    }
+
+    destroy() {
+        if (this._documentClickHandler) {
+            document.removeEventListener('click', this._documentClickHandler);
+        }
+        if (this.container) {
+            this.container.innerHTML = '';
+        }
+    }
+}
+
+export default MultiSelect;

--- a/budget/templates/index.php
+++ b/budget/templates/index.php
@@ -2258,15 +2258,11 @@ style('budget', 'budget-app');
                                 </div>
                                 <div class="mapping-field required" data-map-field="description">
                                     <label><?php p($l->t('Description')); ?> <span class="required">*</span></label>
-                                    <select id="map-description" required>
-                                        <option value=""><?php p($l->t('Select column...')); ?></option>
-                                    </select>
+                                    <div id="map-description" class="custom-multiselect"></div>
                                 </div>
                                 <div class="mapping-field" data-map-field="notes">
                                     <label><?php p($l->t('Notes')); ?></label>
-                                    <select id="map-notes">
-                                        <option value=""><?php p($l->t('Select column...')); ?></option>
-                                    </select>
+                                    <div id="map-notes" class="custom-multiselect"></div>
                                     <p class="hint"><?php p($l->t('Column stored in the transaction\'s notes field')); ?></p>
                                 </div>
                                 <div class="mapping-field" data-map-field="type">
@@ -2277,15 +2273,11 @@ style('budget', 'budget-app');
                                 </div>
                                 <div class="mapping-field" data-map-field="vendor">
                                     <label><?php p($l->t('Vendor/Payee')); ?></label>
-                                    <select id="map-vendor">
-                                        <option value=""><?php p($l->t('Select column...')); ?></option>
-                                    </select>
+                                    <div id="map-vendor" class="custom-multiselect"></div>
                                 </div>
                                 <div class="mapping-field" data-map-field="reference">
                                     <label><?php p($l->t('Reference/Check Number')); ?></label>
-                                    <select id="map-reference">
-                                        <option value=""><?php p($l->t('Select column...')); ?></option>
-                                    </select>
+                                    <div id="map-reference" class="custom-multiselect"></div>
                                 </div>
                                 <div class="mapping-field" data-map-field="category">
                                     <label><?php p($l->t('Category')); ?></label>

--- a/budget/templates/index.php
+++ b/budget/templates/index.php
@@ -3038,20 +3038,7 @@ style('budget', 'budget-app');
 
                 <div class="control-group">
                     <label id="report-account-label"><?php p($l->t('Account')); ?></label>
-                    <div id="report-account-multiselect" class="account-multiselect">
-                        <button type="button" id="report-account-toggle" class="account-multiselect-toggle"
-                                aria-haspopup="true" aria-expanded="false" aria-labelledby="report-account-label report-account-summary">
-                            <span id="report-account-summary"><?php p($l->t('All Accounts')); ?></span>
-                            <span class="account-multiselect-caret" aria-hidden="true">▾</span>
-                        </button>
-                        <div id="report-account-menu" class="account-multiselect-menu" role="group" style="display: none;">
-                            <label class="account-multiselect-option account-multiselect-all">
-                                <input type="checkbox" id="report-account-all" checked>
-                                <span><?php p($l->t('All Accounts')); ?></span>
-                            </label>
-                            <div id="report-account-options"><!-- populated by JS --></div>
-                        </div>
-                    </div>
+                    <div id="report-account-multiselect" class="custom-multiselect"></div>
                 </div>
 
                 <div class="control-group" id="report-exclude-shared-wrap" style="display: none;">

--- a/budget/tests/Unit/Service/Import/TransactionNormalizerTest.php
+++ b/budget/tests/Unit/Service/Import/TransactionNormalizerTest.php
@@ -1275,4 +1275,102 @@ class TransactionNormalizerTest extends TestCase {
 	public function testNormalizeDescriptionEmpty(): void {
 		$this->assertSame('', $this->normalizer->normalizeDescription(''));
 	}
+
+	// ── Multi-Column Concatenation ──────────────────────────────────
+
+	public function testMapRowConcatenatesMultipleColumnsWithComma(): void {
+		$row = [
+			'date' => '2026-08-11',
+			'amount' => '100.00',
+			'merchant' => 'Supermarket',
+			'details' => 'Weekly Groceries',
+		];
+		$mapping = [
+			'date' => 'date',
+			'amount' => 'amount',
+			'description' => ['merchant', 'details'],
+		];
+
+		$result = $this->normalizer->mapRowToTransaction($row, $mapping);
+
+		$this->assertSame('Supermarket, Weekly Groceries', $result['description']);
+	}
+
+	public function testMapRowConcatenatesMultipleTextColumnsSkipsEmptyValues(): void {
+		$row = [
+			'date' => '2026-08-11',
+			'amount' => '50.00',
+			'shop' => 'Coffee Shop',
+			'location' => '   ',
+			'branch' => 'Downtown Branch',
+		];
+		$mapping = [
+			'date' => 'date',
+			'amount' => 'amount',
+			'description' => ['shop', 'location', 'branch'],
+		];
+
+		$result = $this->normalizer->mapRowToTransaction($row, $mapping);
+
+		$this->assertSame('Coffee Shop, Downtown Branch', $result['description']);
+	}
+
+	public function testMapRowConcatenatesNotesVendorReference(): void {
+		$row = [
+			'date' => '2026-08-11',
+			'amount' => '75.00',
+			'description' => 'Main Store',
+			'note_1' => 'Note Line 1',
+			'note_2' => 'Note Line 2',
+			'vendor_1' => 'Vendor Name',
+			'vendor_2' => 'Vendor Code',
+			'reference_1' => 'Ref Part 1',
+			'reference_2' => 'Ref Part 2',
+		];
+		$mapping = [
+			'date' => 'date',
+			'amount' => 'amount',
+			'description' => 'description',
+			'notes' => ['note_1', 'note_2'],
+			'vendor' => ['vendor_1', 'vendor_2'],
+			'reference' => ['reference_1', 'reference_2'],
+		];
+
+		$result = $this->normalizer->mapRowToTransaction($row, $mapping);
+
+		$this->assertSame('Note Line 1, Note Line 2', $result['notes']);
+		$this->assertSame('Vendor Name, Vendor Code', $result['vendor']);
+		$this->assertSame('Ref Part 1, Ref Part 2', $result['reference']);
+	}
+
+	public function testMapRowIgnoresArrayMappingForNonTextField(): void {
+		$row = ['2026-08-11', '40.00', 'Transaction', 'Income', 'Expense'];
+		$mapping = [
+			'date' => 0,
+			'amount' => 1,
+			'description' => 2,
+			'type' => [3, 4],
+		];
+
+		$result = $this->normalizer->mapRowToTransaction($row, $mapping);
+
+		$this->assertSame('credit', $result['type']);
+	}
+
+	public function testMapRowArrayMappingWithSingleColumn(): void {
+		$row = [
+			'date' => '2026-08-11',
+			'amount' => '25.00',
+			'payee' => 'Single Payee',
+		];
+		$mapping = [
+			'date' => 'date',
+			'amount' => 'amount',
+			'description' => ['payee'],
+		];
+
+		$result = $this->normalizer->mapRowToTransaction($row, $mapping);
+
+		$this->assertSame('Single Payee', $result['description']);
+	}
 }

--- a/budget/tests/Unit/Service/ImportTemplateServiceTest.php
+++ b/budget/tests/Unit/Service/ImportTemplateServiceTest.php
@@ -106,6 +106,51 @@ class ImportTemplateServiceTest extends TestCase {
         $this->assertEquals($mapping, $template->getParsedMapping());
     }
 
+    public function testCreateCsvSupportsArrayMappings(): void {
+        $this->mapper->method('nameExists')->willReturn(false);
+        $this->mapper->method('insert')->willReturnCallback(fn (ImportTemplate $t) => $t);
+
+        $mapping = [
+            'date' => 'Date',
+            'amount' => 'Amount',
+            'description' => ['Memo', 'Payee'],
+            'notes' => ['Extra1', 'Extra2'],
+        ];
+
+        $template = $this->service->create('user1', 'Array Mapping', 'csv', $mapping);
+
+        $this->assertEquals($mapping, $template->getParsedMapping());
+    }
+
+    public function testCreateCsvDropsArrayMappingsForNonTextFields(): void {
+        $this->mapper->method('nameExists')->willReturn(false);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Map either an amount column or separate income/expense columns, but not both');
+
+        $mapping = [
+            'date' => 'Date',
+            'amount' => ['Amount', 'Credit'],
+            'description' => 'Memo',
+        ];
+
+        $this->service->create('user1', 'Scalar-only mapping', 'csv', $mapping);
+    }
+
+    public function testCreateCsvDropsBlankOnlyArrayMappings(): void {
+        $this->mapper->method('nameExists')->willReturn(false);
+        $this->mapper->method('insert')->willReturnCallback(fn (ImportTemplate $t) => $t);
+
+        $mapping = [
+            'date' => 'Date',
+            'amount' => 'Amount',
+            'description' => ['   ', '', 'Memo'],
+        ];
+
+        $template = $this->service->create('user1', 'Blank array mapping', 'csv', $mapping);
+
+        $this->assertSame(['date' => 'Date', 'amount' => 'Amount', 'description' => ['Memo']], $template->getParsedMapping());
+    }
+
     public function testCreateCsvDropsUnknownMappingKeys(): void {
         $this->mapper->method('nameExists')->willReturn(false);
         $this->mapper->method('insert')->willReturnCallback(fn (ImportTemplate $t) => $t);

--- a/budget/translationfiles/templates/budget.pot
+++ b/budget/translationfiles/templates/budget.pot
@@ -10313,6 +10313,10 @@ msgstr[1] ""
 msgid "Failed to add selected transfers"
 msgstr ""
 
+#: /app/src/utils/multiselect.js:19
+msgid "Select column(s)..."
+msgstr ""
+
 #: /app/src/utils/formatters.js:228 /app/templates/index.php:5703
 msgid "Mortgage"
 msgstr ""


### PR DESCRIPTION
There are cases where you want multiple CSV fields stored into the transaction description or notes. This PR adds support for selecting multiple columns for textual fields (description, notes, vendor, reference) and concatenates them with a comma into the resulting transaction.

The `MultiSelect` widget is extracted out from the Reports module and used in the Import module.

Compatibility with single-column mapping templates is retained.

Disclaimer: this PR is AI-assisted, but I did my best to build a useful feature in high quality code.