### PR TITLE
refactor: store column indices for unknown mapping headers

### DIFF
--- a/budget/lib/Controller/ImportTemplateController.php
+++ b/budget/lib/Controller/ImportTemplateController.php
@@ -74,7 +74,7 @@ class ImportTemplateController extends Controller {
         array $mapping = [],
         array $accountMapping = [],
         string $delimiter = ',',
-        bool $skipFirstRow = false,
+        bool $skipFirstRow = true,
         bool $skipDuplicates = true,
         bool $applyRules = false,
         ?int $accountId = null

--- a/budget/lib/Service/Import/ParserFactory.php
+++ b/budget/lib/Service/Import/ParserFactory.php
@@ -71,9 +71,9 @@ class ParserFactory {
      * @param string $delimiter CSV delimiter (comma, semicolon, or tab)
      * @return array Parsed data
      */
-    public function parse(string $content, string $format, ?int $limit = null, string $delimiter = ','): array {
+    public function parse(string $content, string $format, ?int $limit = null, string $delimiter = ',', bool $skipFirstRow = true): array {
         return match ($format) {
-            'csv' => $this->parseCsv($content, $limit, $delimiter),
+            'csv' => $this->parseCsv($content, $limit, $delimiter, $skipFirstRow),
             'ofx' => $this->getOfxParser()->parseToTransactionList($content, $limit),
             'qif' => $this->getQifParser()->parseToTransactionList($content, $limit),
             'camt' => $this->getCamtParser()->parseToTransactionList($content, $limit),
@@ -102,9 +102,10 @@ class ParserFactory {
      * @param string $content CSV file content
      * @param int|null $limit Maximum number of records to parse
      * @param string $delimiter CSV delimiter character
-     * @return array Parsed data
+     * @param bool $skipFirstRow Whether the first matching-width line is a header to discard
+     * @return array Parsed data, rows always keyed by plain 0-based column index
      */
-    private function parseCsv(string $content, ?int $limit = null, string $delimiter = ','): array {
+    private function parseCsv(string $content, ?int $limit = null, string $delimiter = ',', bool $skipFirstRow = true): array {
         $content = $this->stripBom($content);
         $lines = explode("\n", $content);
         $dataWidth = $this->detectDataWidth($lines, $delimiter);
@@ -114,7 +115,7 @@ class ParserFactory {
         }
 
         $data = [];
-        $headers = null;
+        $droppedHeader = false;
         $count = 0;
 
         foreach ($lines as $line) {
@@ -129,8 +130,8 @@ class ParserFactory {
                 continue;
             }
 
-            if ($headers === null) {
-                $headers = $this->sanitizeHeaders(array_map('trim', $row));
+            if ($skipFirstRow && !$droppedHeader) {
+                $droppedHeader = true; // this line held the header text — discard it
                 continue;
             }
 
@@ -138,46 +139,11 @@ class ParserFactory {
                 break;
             }
 
-            $data[] = array_combine($headers, array_pad($row, count($headers), ''));
+            $data[] = array_values(array_pad($row, $dataWidth, ''));
             $count++;
         }
 
         return $data;
-    }
-
-    /**
-     * Sanitize raw header strings by assigning synthetic column names ('Column 1', 'Column 2', etc.)
-     * to empty, blank, or duplicate header cells.
-     *
-     * The names are deliberately NOT translated: they end up as the array keys of every parsed
-     * row and are stored verbatim in saved import templates, so a translated name would stop
-     * matching its template as soon as the user changes the interface language.
-     *
-     * @param string[] $rawHeaders
-     * @return string[] Unique, non-empty header names
-     */
-    public function sanitizeHeaders(array $rawHeaders): array {
-        $headers = [];
-        $seen = [];
-
-        foreach ($rawHeaders as $i => $rawHeader) {
-            $candidate = trim((string) $rawHeader);
-
-            if ($candidate === '' || isset($seen[$candidate])) {
-                // A real header may already be called 'Column 2', so keep suffixing until the
-                // name is free - duplicate keys would make array_combine() drop a column.
-                $base = 'Column ' . ($i + 1);
-                $candidate = $base;
-                for ($n = 2; isset($seen[$candidate]); $n++) {
-                    $candidate = $base . ' (' . $n . ')';
-                }
-            }
-
-            $seen[$candidate] = true;
-            $headers[] = $candidate;
-        }
-
-        return $headers;
     }
 
     /**
@@ -234,7 +200,7 @@ class ParserFactory {
     /**
      * Count rows in content.
      */
-    public function countRows(string $content, string $format, string $delimiter = ','): int {
+    public function countRows(string $content, string $format, string $delimiter = ',', bool $skipFirstRow = true): int {
         if ($format === 'csv') {
             $content = $this->stripBom($content);
             $lines = explode("\n", $content);
@@ -244,7 +210,7 @@ class ParserFactory {
                 return 0;
             }
 
-            // Count non-empty lines matching the data width, minus 1 for the header
+            // Count non-empty lines matching the data width, minus 1 for the header (if any)
             $count = 0;
             foreach ($lines as $line) {
                 if (empty(trim($line))) {
@@ -254,7 +220,7 @@ class ParserFactory {
                     $count++;
                 }
             }
-            return max(0, $count - 1);
+            return $skipFirstRow ? max(0, $count - 1) : $count;
         }
 
         // For other formats, use parsed array count

--- a/budget/lib/Service/Import/TransactionNormalizer.php
+++ b/budget/lib/Service/Import/TransactionNormalizer.php
@@ -116,11 +116,15 @@ class TransactionNormalizer {
                 if (is_bool($col) || !is_scalar($col)) {
                     continue;
                 }
-                $col = trim((string) $col);
-                if ($col === '' || in_array($col, $cols, true)) {
+                if (is_int($col)) {
+                    $clean = $col;
+                } else {
+                    $clean = trim((string) $col);
+                }
+                if ($clean === '' || in_array($clean, $cols, true)) {
                     continue;
                 }
-                $cols[] = $col;
+                $cols[] = $clean;
             }
             if ($cols === []) {
                 unset($mapping[$field]);
@@ -176,7 +180,7 @@ class TransactionNormalizer {
 
         // Check for dual-column approach (income + expense)
         // Parse amount first, then check numeric zero to handle all locale formats (0, 0.00, 0,00, etc.)
-        if (!empty($mapping['incomeColumn']) && isset($row[$mapping['incomeColumn']])) {
+        if (self::mapsColumn($mapping, 'incomeColumn') && isset($row[$mapping['incomeColumn']])) {
             $incomeValue = trim($row[$mapping['incomeColumn']]);
             if ($incomeValue !== '') {
                 $parsed = $this->parseAmount($incomeValue);
@@ -187,7 +191,7 @@ class TransactionNormalizer {
             }
         }
 
-        if (!empty($mapping['expenseColumn']) && isset($row[$mapping['expenseColumn']])) {
+        if (self::mapsColumn($mapping, 'expenseColumn') && isset($row[$mapping['expenseColumn']])) {
             $expenseValue = trim($row[$mapping['expenseColumn']]);
             if ($expenseValue !== '') {
                 $parsed = $this->parseAmount($expenseValue);
@@ -211,7 +215,7 @@ class TransactionNormalizer {
             $mappedType = $this->parseTypeValue($transaction['type'] ?? null);
             if ($mappedType !== null) {
                 $type = $mappedType;
-            } elseif ($this->mapsColumn($mapping, 'type')) {
+            } elseif (self::mapsColumn($mapping, 'type')) {
                 // A type column was mapped but this row's value was blank or
                 // unrecognized, so the row falls back to the sign. Mark it so
                 // the preview can say how many rows are guessing.
@@ -228,17 +232,17 @@ class TransactionNormalizer {
         $transaction['type'] = $type;
 
         // Attach category name metadata if mapped
-        if (!empty($mapping['category']) && !empty($row[$mapping['category']])) {
+        if (self::mapsColumn($mapping, 'category') && !empty($row[$mapping['category']])) {
             $transaction['_categoryName'] = trim($row[$mapping['category']]);
         }
 
         // Attach account name metadata if mapped
-        if (!empty($mapping['account']) && !empty($row[$mapping['account']])) {
+        if (self::mapsColumn($mapping, 'account') && !empty($row[$mapping['account']])) {
             $transaction['_accountName'] = trim($row[$mapping['account']]);
         }
 
         // Attach currency metadata if mapped
-        if (!empty($mapping['currency']) && !empty($row[$mapping['currency']])) {
+        if (self::mapsColumn($mapping, 'currency') && !empty($row[$mapping['currency']])) {
             $transaction['_currency'] = strtoupper(trim($row[$mapping['currency']]));
         }
 
@@ -661,7 +665,7 @@ class TransactionNormalizer {
      * as mapRowToTransaction's mapping loop (column 0 is valid; false/null/''
      * are config flags or "not mapped").
      */
-    private function mapsColumn(array $mapping, string $field): bool {
+    public static function mapsColumn(array $mapping, string $field): bool {
         $column = $mapping[$field] ?? null;
         return !is_bool($column) && $column !== null && $column !== '';
     }

--- a/budget/lib/Service/ImportService.php
+++ b/budget/lib/Service/ImportService.php
@@ -329,7 +329,7 @@ class ImportService {
                     continue;
                 }
                 if (empty($headers)) {
-                    $headers = $this->parserFactory->sanitizeHeaders(array_map('trim', $row));
+                    $headers = array_map('trim', $row);
                     $columns = $headers;
                     $rawPreview[] = $headers;
                 } else {
@@ -616,7 +616,7 @@ class ImportService {
     private function previewSingleAccountImport(string $userId, string $content, string $format, array $mapping, ?int $accountId, bool $skipDuplicates, string $delimiter = ',', ?string $presetId = null): array {
         // Load preset if specified
         $preset = $presetId ? $this->presetRegistry->get($presetId) : null;
-        $hasAccountColumn = ($preset && !empty($preset->getOptions()['accountColumn'])) || !empty($mapping['account']);
+        $hasAccountColumn = ($preset && !empty($preset->getOptions()['accountColumn'])) || TransactionNormalizer::mapsColumn($mapping, 'account');
 
         if (!$accountId && !$hasAccountColumn) {
             throw new \Exception($this->l->t('Account ID is required for single-account imports'));
@@ -630,7 +630,7 @@ class ImportService {
             }
         }
 
-        $data = $this->parserFactory->parse($content, $format, null, $delimiter);
+        $data = $this->parserFactory->parse($content, $format, null, $delimiter, $preset || ($mapping['skipFirstRow'] ?? true));
 
         // Remap CSV headers by position when preset provides canonical headers
         // (makes import language-independent — e.g., Toshl exports in German)
@@ -1149,7 +1149,7 @@ class ImportService {
     private function executeSingleAccountImport(string $userId, string $fileId, string $content, string $format, array $mapping, ?int $accountId, bool $skipDuplicates, bool $applyRules, string $delimiter = ',', ?string $presetId = null): array {
         // Load preset if specified
         $preset = $presetId ? $this->presetRegistry->get($presetId) : null;
-        $hasAccountColumn = ($preset && !empty($preset->getOptions()['accountColumn'])) || !empty($mapping['account']);
+        $hasAccountColumn = ($preset && !empty($preset->getOptions()['accountColumn'])) || TransactionNormalizer::mapsColumn($mapping, 'account');
 
         if (!$accountId && !$hasAccountColumn) {
             throw new \Exception($this->l->t('Account ID is required for single-account imports'));
@@ -1163,7 +1163,7 @@ class ImportService {
             }
         }
 
-        $data = $this->parserFactory->parse($content, $format, null, $delimiter);
+        $data = $this->parserFactory->parse($content, $format, null, $delimiter, $preset || ($mapping['skipFirstRow'] ?? true));
 
         // Remap CSV headers by position when preset provides canonical headers
         if ($preset) {
@@ -1442,7 +1442,7 @@ class ImportService {
         $accountColumn = $preset
             ? ($preset->getOptions()['accountColumn'] ?? null)
             : ($mapping['account'] ?? null);
-        if (!$accountColumn) {
+        if ($accountColumn === null || $accountColumn === '') {
             return ['resolved' => [], 'created' => []];
         }
 
@@ -1465,7 +1465,7 @@ class ImportService {
             }
 
             if (!isset($accountInfo[$name])) {
-                $currency = $currencyColumn && !empty($row[$currencyColumn])
+                $currency = ($currencyColumn !== null && $currencyColumn !== '') && !empty($row[$currencyColumn])
                     ? strtoupper(trim($row[$currencyColumn]))
                     : 'USD';
                 $accountInfo[$name] = [

--- a/budget/lib/Service/ImportTemplateService.php
+++ b/budget/lib/Service/ImportTemplateService.php
@@ -70,7 +70,7 @@ class ImportTemplateService extends AbstractCrudService {
         array $mapping = [],
         array $accountMapping = [],
         string $delimiter = ',',
-        bool $skipFirstRow = false,
+        bool $skipFirstRow = true,
         bool $skipDuplicates = true,
         bool $applyRules = false,
         ?int $accountId = null
@@ -204,6 +204,15 @@ class ImportTemplateService extends AbstractCrudService {
      */
     private function sanitizeMapping(array $mapping, ?array $columnFields = null): array {
         $clean = [];
+        $cleanScalar = static function (mixed $value): mixed {
+            if (is_int($value)) {
+                return $value;
+            }
+
+            $value = trim((string) $value);
+            return $value === '' ? null : $value;
+        };
+
         // Lists (several columns joined into one text field) are only kept on
         // the text targets, trimmed and deduplicated, and a one-column list is
         // stored as the plain column it is — so a template saved through the
@@ -215,12 +224,15 @@ class ImportTemplateService extends AbstractCrudService {
             }
 
             if (is_array($mapping[$field])) {
-                $clean[$field] = $mapping[$field];
+                $clean[$field] = array_values(array_filter(
+                    array_map($cleanScalar, $mapping[$field]),
+                    static fn (mixed $value): bool => $value !== null
+                ));
                 continue;
             }
 
-            $val = trim((string) $mapping[$field]);
-            if ($val !== '') {
+            $val = $cleanScalar($mapping[$field]);
+            if ($val !== null) {
                 $clean[$field] = $val;
             }
         }
@@ -267,10 +279,10 @@ class ImportTemplateService extends AbstractCrudService {
      * @param array<string, mixed> $mapping
      */
     private function assertMappingValid(array $mapping): void {
-        $hasDate = !empty($mapping['date']);
-        $hasDescription = !empty($mapping['description']);
-        $hasAmount = !empty($mapping['amount']);
-        $hasDualColumns = !empty($mapping['incomeColumn']) || !empty($mapping['expenseColumn']);
+        $hasDate = TransactionNormalizer::mapsColumn($mapping, 'date');
+        $hasDescription = TransactionNormalizer::mapsColumn($mapping, 'description');
+        $hasAmount = TransactionNormalizer::mapsColumn($mapping, 'amount');
+        $hasDualColumns = TransactionNormalizer::mapsColumn($mapping, 'incomeColumn') || TransactionNormalizer::mapsColumn($mapping, 'expenseColumn');
 
         if (!$hasDate) {
             throw new \InvalidArgumentException('A date column mapping is required');

--- a/budget/src/modules/import/ImportModule.js
+++ b/budget/src/modules/import/ImportModule.js
@@ -28,6 +28,36 @@ const MAPPABLE_FIELDS = {
 };
 
 /**
+ * Port of (removed) `ParserFactory::sanitizeHeaders()` — same untranslated
+ * "Column N" / "Column N (2)" fallback for blank or duplicate header cells.
+ * @param {string[]} rawHeaders
+ * @returns {string[]}
+ */
+function sanitizeHeaders(rawHeaders) {
+    const headers = [];
+    const seen = new Set();
+
+    rawHeaders.forEach((rawHeader, i) => {
+        let candidate = String(rawHeader ?? '').trim();
+
+        if (candidate === '' || seen.has(candidate)) {
+            const base = t('budget', 'Column: {number}', { number: i + 1 });
+            candidate = base;
+            let n = 2;
+            while (seen.has(candidate)) {
+                candidate = `${base} (${n})`;
+                n++;
+            }
+        }
+
+        seen.add(candidate);
+        headers.push(candidate);
+    });
+
+    return headers;
+}
+
+/**
  * Mapping target -> the select that holds it. One list, so the mapping the UI
  * reads (getCurrentMapping) and the one it writes back from a saved template
  * cannot drift apart.
@@ -366,11 +396,70 @@ export default class ImportModule {
 
     applyColumnMappingToForm(mapping, fields) {
         if (!mapping || !Object.keys(mapping).length) return;
+        const isCsv = this.importFormat === 'csv';
 
         fields.forEach(field => {
             const el = document.getElementById(MAPPING_SELECT_IDS[field]);
-            if (el) this.setSelectValue(el, mapping[field]);
+            if (!el) return;
+            let value = mapping[field];
+            if (isCsv && value !== undefined && value !== null && value !== '') {
+                value = Array.isArray(value)
+                    ? value.map(v => this.resolveTemplateColumn(v)).filter(v => v !== null)
+                    : this.resolveTemplateColumn(value);
+            }
+            this.setSelectValue(el, value);
         });
+    }
+
+    /**
+     * Resolve one stored template value back to the live column index this
+     * format's selects use: a string is tried as a verbatim header match
+     * first, falling back to reading a `Column N` shaped string as index N-1.
+     * And a bare number resolves to a 0-indexed column number.
+     */
+    resolveTemplateColumn(value) {
+        if (typeof value === 'number') return String(value);
+        if (typeof value !== 'string' || value === '') return null;
+
+        const labels = this.columnLabels || [];
+        const index = labels.indexOf(value);
+        if (index !== -1) return String(index);
+
+        const legacyMatch = value.match(/^Column (\d+)$/);
+        if (legacyMatch) return String(Number(legacyMatch[1]) - 1);
+
+        return null;
+    }
+
+    /**
+     * Convert the live, always-index CSV mapping into what a template should
+     * actually store: the real header name when it exists. Otherwise there is
+     * no real header to store — so store the index.
+     */
+    toTemplateMapping(mapping) {
+        if (this.importFormat !== 'csv') return mapping;
+
+        const rawColumns = this.rawColumns || [];
+        const labels = this.columnLabels || [];
+        const hasHeaderRow = !!mapping.skipFirstRow;
+
+        const columnValue = (value) => {
+            const index = Number(value);
+            const hasRealHeader = hasHeaderRow && (rawColumns[index] ?? '').trim() !== '';
+            return hasRealHeader ? labels[index] : index;
+        };
+
+        const result = {};
+        Object.entries(mapping).forEach(([field, value]) => {
+            if (value === null || value === undefined || value === '' || typeof value === 'boolean') {
+                result[field] = value;
+            } else if (Array.isArray(value)) {
+                result[field] = value.map(columnValue);
+            } else {
+                result[field] = columnValue(value);
+            }
+        });
+        return result;
     }
 
     /**
@@ -430,7 +519,7 @@ export default class ImportModule {
         const requestBody = { name, format, skipDuplicates };
 
         if (format === 'csv') {
-            const mapping = this.getCurrentMapping();
+            const mapping = this.toTemplateMapping(this.getCurrentMapping());
             requestBody.mapping = mapping;
             requestBody.delimiter = document.getElementById('csv-delimiter')?.value || ',';
             requestBody.skipFirstRow = !!mapping.skipFirstRow;
@@ -887,9 +976,18 @@ export default class ImportModule {
     }
 
     populateColumnMappings(columns) {
-        // Kept for highlightMappedColumns, which has to turn a select's column
-        // name back into its position in the preview table.
-        this.previewColumns = Array.isArray(columns) ? columns.slice() : [];
+        const isCsv = this.importFormat === 'csv';
+
+        // CSV columns are always mapped by index now, whether or not the file
+        // has real headers — the label shown is the sanitized header text (or
+        // a synthesized "Column N" placeholder), but the value the selects and
+        // the live import request carry is the position, never the label.
+        this.rawColumns = (columns || []).map(c => String(c));
+        this.columnLabels = isCsv ? sanitizeHeaders(this.rawColumns) : this.rawColumns.slice();
+        // Kept for highlightMappedColumns, which has to turn a select's value
+        // back into its position in the preview table.
+        this.previewColumns = isCsv ? this.columnLabels.map((_, i) => String(i)) : this.columnLabels.slice();
+
         this.initMultiSelects();
         this.resetImportMultiSelects();
 
@@ -908,31 +1006,43 @@ export default class ImportModule {
             'map-currency': document.getElementById('map-currency')
         };
 
+        // Options: for CSV, value is the column index and label is the
+        // sanitized header text; for other formats, value and label are both
+        // the format's own fixed field name, as before.
+        const options = isCsv
+            ? this.columnLabels.map((label, i) => ({ value: String(i), label }))
+            : this.columnLabels;
+
         // Clear existing options and add columns
         Object.entries(mappingSelects).forEach(([id, select]) => {
             if (!select) return;
             const multiSelect = this.multiSelects[SELECT_ID_TO_FIELD[id]];
             if (multiSelect) {
-                multiSelect.setOptions(columns);
+                multiSelect.setOptions(options);
             } else {
                 const firstOption = select.firstElementChild;
                 select.innerHTML = '';
                 if (firstOption) select.appendChild(firstOption);
 
-                columns.forEach((column, _index) => {
+                options.forEach(opt => {
                     const option = document.createElement('option');
-                    option.value = column;
-                    option.textContent = column;
+                    if (isCsv) {
+                        option.value = opt.value;
+                        option.textContent = opt.label;
+                    } else {
+                        option.value = opt;
+                        option.textContent = opt;
+                    }
                     select.appendChild(option);
                 });
             }
         });
 
         // Auto-detect common column mappings
-        this.autoDetectMappings(columns, mappingSelects);
+        this.autoDetectMappings(this.columnLabels, mappingSelects, isCsv);
     }
 
-    autoDetectMappings(columns, mappingSelects) {
+    autoDetectMappings(columns, mappingSelects, isCsv = this.importFormat === 'csv') {
         const patterns = {
             'map-date': ['date', 'transaction date', 'trans date', 'posting date'],
             'map-amount': ['amount', 'transaction amount', 'trans amount', 'value'],
@@ -954,15 +1064,14 @@ export default class ImportModule {
             const select = mappingSelects[fieldId];
             if (!select) return;
 
-            const matchingColumn = columns.find(col =>
+            const matchIndex = columns.findIndex(col =>
                 patternList.some(pattern =>
                     col.toLowerCase().includes(pattern.toLowerCase())
                 )
             );
+            if (matchIndex === -1) return;
 
-            if (matchingColumn) {
-                this.setSelectValue(select, matchingColumn);
-            }
+            this.setSelectValue(select, isCsv ? String(matchIndex) : columns[matchIndex]);
         });
     }
 
@@ -1038,12 +1147,20 @@ export default class ImportModule {
         thead.innerHTML = '';
         tbody.innerHTML = '';
 
+        // CSV header labels come from populateColumnMappings' sanitized list
+        // (blank/duplicate cells already resolved); other formats still take
+        // their fixed column names straight from the preview's own header row.
+        const isCsv = this.importFormat === 'csv';
+        const headerLabels = isCsv ? (this.columnLabels || previewData[0].map(h => String(h)))
+            : previewData[0].map(header => String(header));
+        if (!isCsv) {
         // The rendered header row is what highlightMappedColumns indexes into,
         // so take the column order from it rather than from the upload response.
-        this.previewColumns = previewData[0].map(header => String(header));
+            this.previewColumns = headerLabels;
+        }
 
         const headerRow = document.createElement('tr');
-        previewData[0].forEach((header, index) => {
+        headerLabels.forEach((header, index) => {
             const th = document.createElement('th');
             th.textContent = `${index + 1}. ${header}`;
             headerRow.appendChild(th);
@@ -1885,6 +2002,10 @@ export default class ImportModule {
         // Importing duplicates is a per-import opt-in — never carry it over
         const importDuplicates = document.getElementById('import-duplicates');
         if (importDuplicates) importDuplicates.checked = false;
+
+        // A header row is the default assumption for a fresh, template-less upload
+        const skipFirstRow = document.getElementById('skip-first-row');
+        if (skipFirstRow) skipFirstRow.checked = true;
 
         // Reset account selection UI
         const singleAccountSection = document.getElementById('single-account-selection');

--- a/budget/templates/index.php
+++ b/budget/templates/index.php
@@ -2322,7 +2322,7 @@ style('budget', 'budget-app');
 
                         <div class="mapping-options">
                             <label data-map-field="skipFirstRow">
-                                <input type="checkbox" id="skip-first-row">
+                                <input type="checkbox" id="skip-first-row" checked>
                                 <?php p($l->t('Skip first row (headers)')); ?>
                             </label>
                             <label>

--- a/budget/tests/Unit/Controller/ImportTemplateControllerTest.php
+++ b/budget/tests/Unit/Controller/ImportTemplateControllerTest.php
@@ -82,7 +82,7 @@ class ImportTemplateControllerTest extends TestCase {
     public function testCreateOfxRoutingReturnsCreated(): void {
         $this->service->expects($this->once())
             ->method('create')
-            ->with('user1', 'OFX Bank', 'ofx', [], ['1234' => 5], ',', false, true, false, null)
+            ->with('user1', 'OFX Bank', 'ofx', [], ['1234' => 5], ',', true, true, false, null)
             ->willReturn($this->makeTemplate());
 
         $response = $this->controller->create('OFX Bank', 'ofx', [], ['1234' => 5]);

--- a/budget/tests/Unit/Service/Import/ParserFactoryTest.php
+++ b/budget/tests/Unit/Service/Import/ParserFactoryTest.php
@@ -68,9 +68,9 @@ class ParserFactoryTest extends TestCase {
         $result = $this->factory->parse($csv, 'csv');
 
         $this->assertCount(2, $result);
-        $this->assertEquals('2026-01-01', $result[0]['Date']);
-        $this->assertEquals('100.00', $result[0]['Amount']);
-        $this->assertEquals('Groceries', $result[0]['Description']);
+        $this->assertEquals('2026-01-01', $result[0][0]);
+        $this->assertEquals('100.00', $result[0][1]);
+        $this->assertEquals('Groceries', $result[0][2]);
     }
 
     public function testParseCsvWithLimit(): void {
@@ -87,7 +87,7 @@ class ParserFactoryTest extends TestCase {
         $result = $this->factory->parse($csv, 'csv', null, ';');
 
         $this->assertCount(1, $result);
-        $this->assertEquals('100.00', $result[0]['Amount']);
+        $this->assertEquals('100.00', $result[0][1]);
     }
 
     public function testParseCsvStripsUtf8Bom(): void {
@@ -96,7 +96,7 @@ class ParserFactoryTest extends TestCase {
         $result = $this->factory->parse($csv, 'csv');
 
         $this->assertCount(1, $result);
-        $this->assertArrayHasKey('Date', $result[0]);
+        $this->assertArrayHasKey(0, $result[0]);
     }
 
     public function testParseCsvSkipsMetadataPreamble(): void {
@@ -106,7 +106,7 @@ class ParserFactoryTest extends TestCase {
         $result = $this->factory->parse($csv, 'csv');
 
         $this->assertCount(2, $result);
-        $this->assertEquals('Groceries', $result[0]['Description']);
+        $this->assertEquals('Groceries', $result[0][2]);
     }
 
     public function testParseCsvEmptyContentReturnsEmpty(): void {
@@ -150,26 +150,21 @@ class ParserFactoryTest extends TestCase {
         $result = $this->factory->parse($csv, 'csv', null, ';');
 
         $this->assertCount(2, $result);
-        // Headers should be clean (no BOM, no quotes)
-        $this->assertArrayHasKey('Buchungsdatum', $result[0]);
-        $this->assertArrayHasKey('Betrag (€)', $result[0]);
-        $this->assertArrayHasKey('Zahlungsempfänger*in', $result[0]);
-        // Values should be clean
-        $this->assertEquals('25.03.26', $result[0]['Buchungsdatum']);
-        $this->assertEquals('-57,68', $result[0]['Betrag (€)']);
-        $this->assertEquals('Lidl', $result[0]['Zahlungsempfänger*in']);
+        // Headers are no longer used as row keys — rows are always index-keyed
+        $this->assertEquals('25.03.26', $result[0][0]);
+        $this->assertEquals('-57,68', $result[0][7]);
+        $this->assertEquals('Lidl', $result[0][4]);
     }
 
     public function testParseCsvBomWithQuotedValuesHeadersMatchColumnNames(): void {
-        // Verify that headers from parse() match what buildUploadResponse would produce
-        // after BOM stripping (the actual bug was a mismatch between these two)
+        // Verify BOM/quote stripping no longer depends on the header row at all,
+        // since rows are parsed by position (the original bug predates that)
         $csv = "\xEF\xBB\xBF\"Date\";\"Amount\";\"Description\"\n\"2026-01-01\";\"100.00\";\"Groceries\"\n";
 
         $result = $this->factory->parse($csv, 'csv', null, ';');
 
         $this->assertCount(1, $result);
-        $this->assertArrayHasKey('Date', $result[0]);
-        $this->assertEquals('100.00', $result[0]['Amount']);
+        $this->assertEquals('100.00', $result[0][1]);
     }
 
     // ===== detectDataWidth =====
@@ -203,12 +198,10 @@ class ParserFactoryTest extends TestCase {
         $result = $this->factory->parse($csv, 'csv', null, ';');
 
         $this->assertCount(1, $result);
-        // Should use actual data headers, not preamble
-        $this->assertArrayHasKey('Buchungsdatum', $result[0]);
-        $this->assertArrayHasKey('Betrag (€)', $result[0]);
-        $this->assertEquals('25.03.26', $result[0]['Buchungsdatum']);
-        $this->assertEquals('Lidl', $result[0]['Zahlungsempfänger*in']);
-        $this->assertEquals('-57,68', $result[0]['Betrag (€)']);
+        // Should use actual data rows, not preamble, keyed by position
+        $this->assertEquals('25.03.26', $result[0][0]);
+        $this->assertEquals('Lidl', $result[0][4]);
+        $this->assertEquals('-57,68', $result[0][8]);
     }
 
     // ===== parse unsupported format =====
@@ -244,6 +237,37 @@ class ParserFactoryTest extends TestCase {
         $this->assertEquals(0, $count);
     }
 
+    // ===== skipFirstRow (header-less CSV) =====
+
+    public function testParseCsvSkipFirstRowFalseTreatsEveryLineAsData(): void {
+        $csv = "2026-01-01,100.00,Groceries\n2026-01-02,50.00,Gas\n";
+
+        $result = $this->factory->parse($csv, 'csv', null, ',', false);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('2026-01-01', $result[0][0]);
+        $this->assertEquals('100.00', $result[0][1]);
+        $this->assertEquals('Groceries', $result[0][2]);
+        $this->assertEquals('2026-01-02', $result[1][0]);
+    }
+
+    public function testParseCsvSkipFirstRowDefaultsTrue(): void {
+        $csv = "Date,Amount,Description\n2026-01-01,100.00,Groceries\n";
+
+        $result = $this->factory->parse($csv, 'csv');
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('2026-01-01', $result[0][0]);
+    }
+
+    public function testCountRowsSkipFirstRowFalseCountsEveryLine(): void {
+        $csv = "2026-01-01,100.00\n2026-01-02,50.00\n2026-01-03,30.00\n";
+
+        $count = $this->factory->countRows($csv, 'csv', ',', false);
+
+        $this->assertEquals(3, $count);
+    }
+
     // ===== getSupportedFormats =====
 
     public function testGetSupportedFormats(): void {
@@ -263,65 +287,6 @@ class ParserFactoryTest extends TestCase {
         $this->assertArrayHasKey('transactions', $result);
         $this->assertEmpty($result['accounts']);
         $this->assertCount(1, $result['transactions']);
-    }
-
-    // ===== sanitizeHeaders & untitled columns =====
-
-    public function testSanitizeHeadersWithUntitledColumns(): void {
-        $raw = ['Date', '', 'Amount', '  ', 'Notes'];
-        $sanitized = $this->factory->sanitizeHeaders($raw);
-
-        $this->assertEquals(['Date', 'Column 2', 'Amount', 'Column 4', 'Notes'], $sanitized);
-    }
-
-    public function testSanitizeHeadersAvoidsClashWithARealColumnName(): void {
-        $raw = ['Column 2', '', 'Amount'];
-        $sanitized = $this->factory->sanitizeHeaders($raw);
-
-        $this->assertEquals(['Column 2', 'Column 2 (2)', 'Amount'], $sanitized);
-        $this->assertCount(3, array_unique($sanitized));
-    }
-
-    public function testParseCsvKeepsEveryColumnWhenAHeaderClashes(): void {
-        $csv = "Column 2,,Amount\n2026-01-01,Extra,100.00\n";
-
-        $result = $this->factory->parse($csv, 'csv');
-
-        $this->assertCount(3, $result[0]);
-        $this->assertEquals('2026-01-01', $result[0]['Column 2']);
-        $this->assertEquals('Extra', $result[0]['Column 2 (2)']);
-        $this->assertEquals('100.00', $result[0]['Amount']);
-    }
-
-    public function testSanitizeHeadersWithDuplicateHeaders(): void {
-        $raw = ['Date', 'Amount', 'Date', 'Amount'];
-        $sanitized = $this->factory->sanitizeHeaders($raw);
-
-        $this->assertEquals(['Date', 'Amount', 'Column 3', 'Column 4'], $sanitized);
-    }
-
-    public function testParseCsvWithUntitledColumns(): void {
-        $csv = "Date,,Amount,,Notes\n2026-01-01,Extra,100.00,Foo,Groceries\n";
-
-        $result = $this->factory->parse($csv, 'csv');
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('2026-01-01', $result[0]['Date']);
-        $this->assertEquals('Extra', $result[0]['Column 2']);
-        $this->assertEquals('100.00', $result[0]['Amount']);
-        $this->assertEquals('Foo', $result[0]['Column 4']);
-        $this->assertEquals('Groceries', $result[0]['Notes']);
-    }
-
-    public function testParseCsvWithAllUntitledColumns(): void {
-        $csv = ",,\n2026-01-01,100.00,Groceries\n";
-
-        $result = $this->factory->parse($csv, 'csv');
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('2026-01-01', $result[0]['Column 1']);
-        $this->assertEquals('100.00', $result[0]['Column 2']);
-        $this->assertEquals('Groceries', $result[0]['Column 3']);
     }
 
     // ===== camt.053 (#350) =====

--- a/budget/tests/Unit/Service/Import/TransactionNormalizerTest.php
+++ b/budget/tests/Unit/Service/Import/TransactionNormalizerTest.php
@@ -1381,6 +1381,28 @@ class TransactionNormalizerTest extends TestCase {
 		$this->assertArrayNotHasKey('_currency', $result);
 	}
 
+	// Regression for the "column 0 looks empty" bug: incomeColumn, expenseColumn,
+	// category, account and currency all used to test the mapping with empty(),
+	// which treats 0/"0" as unmapped — breaking the single most common index.
+	public function testMapRowResolvesFieldsMappedToColumnIndexZero(): void {
+		$row = ['100.00', '2026-08-11', 'Food', 'Main', 'USD'];
+		$mapping = [
+			'incomeColumn' => 0,
+			'date' => 1,
+			'category' => 2,
+			'account' => 3,
+			'currency' => 4,
+		];
+
+		$result = $this->normalizer->mapRowToTransaction($row, $mapping);
+
+		$this->assertEqualsWithDelta(100.00, $result['amount'], 0.001);
+		$this->assertSame('credit', $result['type']);
+		$this->assertSame('Food', $result['_categoryName']);
+		$this->assertSame('Main', $result['_accountName']);
+		$this->assertSame('USD', $result['_currency']);
+	}
+
 	// The checklist sends every selection as a list, one column included. A
 	// one-column list has to map through the scalar path so the #340 hash
 	// freeze still sees the raw cell and the import id does not change.

--- a/budget/tests/Unit/Service/ImportServiceTest.php
+++ b/budget/tests/Unit/Service/ImportServiceTest.php
@@ -217,6 +217,36 @@ class ImportServiceTest extends TestCase {
         $this->assertSame(0, $result['categorizedCount']);
     }
 
+    // Regression: skipFirstRow must actually reach the parser now, and a
+    // mapping field at column index 0 must resolve (the empty() bug fix).
+    public function testPreviewSingleAccountImportForwardsSkipFirstRowAndAcceptsColumnZero(): void {
+        $this->mockImportFile('file.csv', "2025-01-01,100,Test\n");
+        $this->parserFactory->method('detectFormat')->willReturn('csv');
+        $this->parserFactory->expects($this->once())
+            ->method('parse')
+            ->with($this->anything(), 'csv', null, ',', false)
+            ->willReturn([
+                ['2025-01-01', '100', 'Test'],
+            ]);
+
+        $this->accountMapper->method('find')->willReturn($this->makeAccount(1, 'Checking'));
+        $this->normalizer->method('mapRowToTransaction')->willReturn([
+            'date' => '2025-01-01', 'amount' => 100.0, 'description' => 'Test', 'type' => 'credit',
+        ]);
+        $this->normalizer->method('generateImportId')->willReturn('imp_001');
+        $this->duplicateDetector->method('isDuplicate')->willReturn(false);
+        $this->ruleApplicator->method('applyRules')->willReturnArgument(1);
+
+        $result = $this->service->previewImport(
+            'user1',
+            'file.csv',
+            ['date' => 0, 'amount' => 1, 'description' => 2, 'skipFirstRow' => false],
+            1
+        );
+
+        $this->assertEquals(1, $result['validTransactions']);
+    }
+
     public function testPreviewSingleAccountSkipsDuplicates(): void {
         $this->mockImportFile('file.csv', 'data');
         $this->parserFactory->method('detectFormat')->willReturn('csv');
@@ -872,7 +902,10 @@ class ImportServiceTest extends TestCase {
 
     // ===== buildUploadResponse with untitled headers =====
 
-    public function testBuildUploadResponseSanitizesUntitledHeaders(): void {
+    public function testBuildUploadResponseSendsRawUntitledHeaders(): void {
+        // Blank/duplicate-header fallback labelling moved to the frontend
+        // (ImportModule.js's ported sanitizeHeaders) — the backend now sends
+        // the raw, trimmed header cells as-is, blanks included.
         $realParserFactory = new ParserFactory();
         $refParser = new \ReflectionProperty(ImportService::class, 'parserFactory');
         $refParser->setAccessible(true);
@@ -894,9 +927,9 @@ class ImportServiceTest extends TestCase {
             ','
         );
 
-        $this->assertEquals(['Date', 'Column 2', 'Amount', 'Column 4', 'Notes'], $result['columns']);
+        $this->assertEquals(['Date', '', 'Amount', '', 'Notes'], $result['columns']);
         $this->assertEquals('Date', $result['preview'][0][0]);
-        $this->assertEquals('Column 2', $result['preview'][0][1]);
-        $this->assertEquals('Column 4', $result['preview'][0][3]);
+        $this->assertEquals('', $result['preview'][0][1]);
+        $this->assertEquals('', $result['preview'][0][3]);
     }
 }

--- a/budget/tests/Unit/Service/ImportTemplateServiceTest.php
+++ b/budget/tests/Unit/Service/ImportTemplateServiceTest.php
@@ -51,6 +51,39 @@ class ImportTemplateServiceTest extends TestCase {
         $this->assertEquals(',', $template->getDelimiter());
     }
 
+    public function testCreateDefaultsSkipFirstRowToTrue(): void {
+        $this->mapper->method('nameExists')->willReturn(false);
+        $this->mapper->method('insert')->willReturnCallback(fn (ImportTemplate $t) => $t);
+
+        $template = $this->service->create('user1', 'Bank', 'csv', $this->validMapping());
+
+        $this->assertTrue($template->getSkipFirstRow());
+    }
+
+    // Regression: a mapping field pointed at column index 0 (the file's first
+    // column, the common case for a header-less file) used to be rejected by
+    // assertMappingValid()'s empty() checks, which treat "0" as unmapped.
+    public function testCreateCsvAcceptsColumnIndexZero(): void {
+        $this->mapper->method('nameExists')->willReturn(false);
+        $this->mapper->method('insert')->willReturnCallback(fn (ImportTemplate $t) => $t);
+
+        $mapping = ['date' => '0', 'amount' => '1', 'description' => '2'];
+        $template = $this->service->create('user1', 'Headerless', 'csv', $mapping, [], ',', false);
+
+        $this->assertEquals($mapping, $template->getParsedMapping());
+        $this->assertFalse($template->getSkipFirstRow());
+    }
+
+    public function testCreateCsvKeepsIntegerColumnIndexesAsIntegers(): void {
+        $this->mapper->method('nameExists')->willReturn(false);
+        $this->mapper->method('insert')->willReturnCallback(fn (ImportTemplate $t) => $t);
+
+        $mapping = ['date' => 0, 'amount' => 1, 'description' => 2];
+        $template = $this->service->create('user1', 'Headerless Ints', 'csv', $mapping, [], ',', false);
+
+        $this->assertSame($mapping, $template->getParsedMapping());
+    }
+
     public function testCreateRejectsUnsupportedFormat(): void {
         $this->expectException(\InvalidArgumentException::class);
         $this->service->create('user1', 'Bank', 'xml', $this->validMapping());
@@ -166,6 +199,22 @@ class ImportTemplateServiceTest extends TestCase {
         $template = $this->service->create('user1', 'Untrimmed array mapping', 'csv', $mapping);
 
         $this->assertSame(['date' => 'Date', 'amount' => 'Amount', 'description' => ['Memo', 'Payee']], $template->getParsedMapping());
+    }
+
+    public function testCreateCsvKeepsIntegerArrayMappingsAsArrays(): void {
+        $this->mapper->method('nameExists')->willReturn(false);
+        $this->mapper->method('insert')->willReturnCallback(fn (ImportTemplate $t) => $t);
+
+        $mapping = [
+            'date' => 'Date',
+            'amount' => 'Amount',
+            'description' => [0, 1, 2],
+            'notes' => ['  Notes  ', 3],
+        ];
+
+        $template = $this->service->create('user1', 'Integer array mapping', 'csv', $mapping);
+
+        $this->assertSame(['date' => 'Date', 'amount' => 'Amount', 'description' => [0, 1, 2], 'notes' => ['Notes', 3]], $template->getParsedMapping());
     }
 
     public function testCreateCsvDropsArrayMappingOnNonTextFieldInsteadOfStoringIt(): void {


### PR DESCRIPTION
And fix `skipFirstRow` functionality - defaults to `true`, matching most common case.

When first row is skipped, all columns are matched by index. Otherwise, only those that were synthesized.

This also allows to move the header synthesis to the frontend, and add translations. Backwards compatibility with `Column N` is retained (not `Column N (Y)`, though).

Next step will be to refresh the import preview and selects when separator and `skipFirstRow` changes.